### PR TITLE
Upgrade ingress manifests to current Kubernetes API

### DIFF
--- a/aws/api-ingress.yaml
+++ b/aws/api-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,9 +12,13 @@ spec:
     - api.pvcy.customer.com
     secretName: nginx-api-secret
   rules:
-  - host: api.pvcy.customer.com
-    http:
-      paths:
-      - backend:
-          serviceName: nginx-api-service
-          servicePort: 80
+    - host: api.pvcy.customer.com
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nginx-api-service
+                port:
+                  number: 80

--- a/aws/app-ingress.yaml
+++ b/aws/app-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,9 +12,13 @@ spec:
     - app.pvcy.customer.com
     secretName: analyzer-app-secret
   rules:
-  - host: app.pvcy.customer.com
-    http:
-      paths:
-      - backend:
-          serviceName: analyzer-app-service
-          servicePort: 80
+    - host: app.pvcy.customer.com
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: analyzer-app-service
+                port:
+                  number: 80


### PR DESCRIPTION
The `extensions/v1beta1` API was deprecated in Kubernetes 1.22, I think.