### PR TITLE
Update ingresses

### DIFF
--- a/aws/api-ingress.yaml
+++ b/aws/api-ingress.yaml
@@ -15,8 +15,7 @@ spec:
     - host: api.pvcy.customer.com
       http:
         paths:
-          - path: /*
-            pathType: ImplementationSpecific
+          - pathType: ImplementationSpecific
             backend:
               service:
                 name: nginx-api-service

--- a/aws/app-ingress.yaml
+++ b/aws/app-ingress.yaml
@@ -15,8 +15,7 @@ spec:
     - host: app.pvcy.customer.com
       http:
         paths:
-          - path: /*
-            pathType: ImplementationSpecific
+          - pathType: ImplementationSpecific
             backend:
               service:
                 name: analyzer-app-service

--- a/aws/kots-ingress.yaml
+++ b/aws/kots-ingress.yaml
@@ -15,8 +15,7 @@ spec:
   - host: kotsadm.pvcy.customer.com
     http:
       paths:
-        - path: /*
-          pathType: ImplementationSpecific
+        - pathType: ImplementationSpecific
           backend:
             service:
               name: kotsadm

--- a/gcp/api-ingress.yaml
+++ b/gcp/api-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,10 +12,12 @@ spec:
     - api.pvcy.customer.com
     secretName: nginx-api-secret
   rules:
-  - host: api.pvcy.customer.com
-    http:
-      paths:
-      - backend:
-          serviceName: nginx-api-service
-          servicePort: 80
-
+    - host: api.pvcy.customer.com
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nginx-api-service
+                port:
+                  number: 80

--- a/gcp/app-ingress.yaml
+++ b/gcp/app-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,9 +12,12 @@ spec:
     - app.pvcy.customer.com
     secretName: analyzer-app-secret
   rules:
-  - host: app.pvcy.customer.com
-    http:
-      paths:
-      - backend:
-          serviceName: analyzer-app-service
-          servicePort: 80
+    - host: app.pvcy.customer.com
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: analyzer-app-service
+                port:
+                  number: 80

--- a/gcp/kots-ingress.yaml
+++ b/gcp/kots-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  annotations:
@@ -12,9 +12,12 @@ spec:
    - kotsadm.pvcy.customer.com
    secretName: kotsadm-app-secret
  rules:
- - host: kotsadm.pvcy.customer.com
-   http:
-     paths:
-     - backend:
-         serviceName: kotsadm
-         servicePort: 3000
+  - host: kotsadm.pvcy.customer.com
+    http:
+      paths:
+        - pathType: ImplementationSpecific
+          backend:
+            service:
+              name: kotsadm
+              port:
+                number: 3000


### PR DESCRIPTION
This PR:
- removes the extra `path: /*` property. Since we're matching on host we don't need this, and in at least one case this was causing the ingress to return a 404
- Updates the GCP copies to be the same. I don't think these are actually cloud specific, so I just copied them over.