### PR TITLE
Update image to use new registry and latest image

### DIFF
--- a/aws/external-dns/deploy.yaml
+++ b/aws/external-dns/deploy.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: k8s.gcr.io/external-dns/external-dns:v0.10.2
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/gcp/external-dns/deploy.yaml
+++ b/gcp/external-dns/deploy.yaml
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: k8s.gcr.io/external-dns/external-dns:v0.11.0
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress


### PR DESCRIPTION
closes #5

This bumps the image to the latest and uses the newest version.

refs:
- https://kubernetes-sigs.github.io/external-dns/v0.13.4/tutorials/aws/#deploy-externaldns
- https://kubernetes-sigs.github.io/external-dns/v0.13.4/tutorials/gke/#deploy-externaldns