### PR TITLE
Use documented replacement text GRAFANA_PASSWORD

### DIFF
--- a/aws/prometheus-stack/values.yaml
+++ b/aws/prometheus-stack/values.yaml
@@ -26,7 +26,7 @@ grafana:
     name: Loki
     type: loki
     url: http://loki.loki.svc.cluster.local:3100
-  adminPassword: grafana_45xxxx1
+  adminPassword: GRAFANA_PASSWORD
   enabled: true
   persistence:
     enabled: true


### PR DESCRIPTION
In https://www.privacydynamics.io/docs/enterprise/observability we mention replacing the text `GRAFANA_PASSWORD` with your own password, however that txt doesn't exist in the linked YAML for AWS.

(Note, it IS there for GCP so we only need to fix the AWS copy here)