### PR TITLE
Update ingress service names

### DIFF
--- a/aws/api-ingress.yaml
+++ b/aws/api-ingress.yaml
@@ -18,6 +18,6 @@ spec:
           - pathType: ImplementationSpecific
             backend:
               service:
-                name: nginx-api-service
+                name: nginx-privacy-api
                 port:
                   number: 80

--- a/aws/app-ingress.yaml
+++ b/aws/app-ingress.yaml
@@ -18,6 +18,6 @@ spec:
           - pathType: ImplementationSpecific
             backend:
               service:
-                name: analyzer-app-service
+                name: app
                 port:
                   number: 80

--- a/aws/external-dns/deploy.yaml
+++ b/aws/external-dns/deploy.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.2
+        image: registry.k8s.io/external-dns/external-dns:v0.13.5
         args:
         - --source=service
         - --source=ingress

--- a/gcp/api-ingress.yaml
+++ b/gcp/api-ingress.yaml
@@ -18,6 +18,6 @@ spec:
           - pathType: ImplementationSpecific
             backend:
               service:
-                name: nginx-api-service
+                name: nginx-privacy-api
                 port:
                   number: 80

--- a/gcp/app-ingress.yaml
+++ b/gcp/app-ingress.yaml
@@ -18,6 +18,6 @@ spec:
           - pathType: ImplementationSpecific
             backend:
               service:
-                name: analyzer-app-service
+                name: app
                 port:
                   number: 80

--- a/gcp/external-dns/deploy.yaml
+++ b/gcp/external-dns/deploy.yaml
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.2
+          image: registry.k8s.io/external-dns/external-dns:v0.13.5
           args:
             - --source=service
             - --source=ingress


### PR DESCRIPTION
closes #11

This PR: 
- updates the service names that our Ingress resources target to reflect the names used in the latest Helm charts. See doc in https://github.com/pvcy/onprem-infrastructure/blob/main/replicated/doc/IngressUpdate.md
- Bumps external DNS to the latest release
