### PR TITLE
update ingress class reference

### DIFF
--- a/aws/api-ingress.yaml
+++ b/aws/api-ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
   name: nginx-api-ingress
   namespace: pvcy
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - api.pvcy.customer.com

--- a/aws/app-ingress.yaml
+++ b/aws/app-ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
   name: analyzer-app-service-ingress
   namespace: pvcy
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - app.pvcy.customer.com

--- a/aws/kots-ingress.yaml
+++ b/aws/kots-ingress.yaml
@@ -2,16 +2,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  annotations:
-   kubernetes.io/ingress.class: "nginx"
    cert-manager.io/cluster-issuer: "letsencrypt-production"
  name: kots-ingress
  namespace: pvcy
 spec:
- tls:
- - hosts:
-   - kotsadm.pvcy.customer.com
-   secretName: kotsadm-app-secret
- rules:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - kotsadm.pvcy.customer.com
+    secretName: kotsadm-app-secret
+  rules:
   - host: kotsadm.pvcy.customer.com
     http:
       paths:

--- a/aws/kots-ingress.yaml
+++ b/aws/kots-ingress.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
- annotations:
-   cert-manager.io/cluster-issuer: "letsencrypt-production"
- name: kots-ingress
- namespace: pvcy
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+  name: kots-ingress
+  namespace: pvcy
 spec:
   ingressClassName: nginx
   tls:

--- a/gcp/api-ingress.yaml
+++ b/gcp/api-ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
   name: nginx-api-ingress
   namespace: pvcy
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - api.pvcy.customer.com

--- a/gcp/app-ingress.yaml
+++ b/gcp/app-ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
   name: analyzer-app-service-ingress
   namespace: pvcy
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - app.pvcy.customer.com

--- a/gcp/kots-ingress.yaml
+++ b/gcp/kots-ingress.yaml
@@ -2,16 +2,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  annotations:
-   kubernetes.io/ingress.class: "nginx"
    cert-manager.io/cluster-issuer: "letsencrypt-production"
  name: kots-ingress
  namespace: pvcy
 spec:
- tls:
- - hosts:
-   - kotsadm.pvcy.customer.com
-   secretName: kotsadm-app-secret
- rules:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - kotsadm.pvcy.customer.com
+    secretName: kotsadm-app-secret
+  rules:
   - host: kotsadm.pvcy.customer.com
     http:
       paths:

--- a/gcp/kots-ingress.yaml
+++ b/gcp/kots-ingress.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
- annotations:
-   cert-manager.io/cluster-issuer: "letsencrypt-production"
- name: kots-ingress
- namespace: pvcy
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+  name: kots-ingress
+  namespace: pvcy
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
Per the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), the `kubernetes.io/ingress.class` annotation has been deprecated. In its place, we should use the `spec.ingressClassName` field.

This PR also fixes an indentation issue in kots-ingress.yaml