### PR TITLE
Terraform resources for Azure Managed Identites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+terraform.tfstate*

--- a/azure/terraform/README.md
+++ b/azure/terraform/README.md
@@ -1,0 +1,32 @@
+# Azure Terraform Configuration Files
+
+## Resources
+
+The Terraform files provided here will create the following resources:
+
+- An Azure DNS Zone for Privacy Dynamics software
+- An Azure Storage Account for backups of the Privacy Dynamics application database
+- Two Managed Identities, one for DNS access and the other for access to the Storage Account
+- Role assignments related to the Managed Identities
+- Three Federated Identity Credentials, each linked to one of the two Managed Identities
+
+The Federated Identity Credentials are linked to Kubernetes ServiceAccount resources through an Annotation referencing the associated Managed Identity's Client ID. This Annotation is created through the applicable Helm charts, which can be deployed via Replicated.
+
+## Variables
+
+The following information needs to be set in the `var.aks_cluster_information` variable in the `variables.tf` file in order for these Terraform files to run correctly:
+
+- `location` = the Azure location (region) for the AKS cluster
+- `resource_group` = the Resource Group containing the AKS cluster
+- `dns_zone_name` = the subdomain for the DNS zone to be created (e.g. `pvcy.example.com`)
+- `storage_account` = the name for the Storage Account to be created
+- `oidc_issuer_url` = the URL of the OpenID Connect (OIDC) Issuer; see the [Azure documentation](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer) for details on finding or creating your cluster's OIDC Issuer URL
+
+## Outputs
+
+After applying these Terraform configuration files, the following outputs will be shown:
+
+- Client ID of the `blob-storage-contributor` Managed Identity = the value for the "Storage Managed Identity Client ID" field during Privacy Dynamics software installation
+- Client ID of the `dns-contributor` Managed Identity = the value for the "DNS Managed Identity ClientID" field during Privacy Dynamics software installation, if opting to include ExternalDNS or cert-manager
+- Azure Subscription ID = required during Privacy Dynamics software installation, if opting to include ExternalDNS or cert-manager 
+- Azure Tenant ID = also required during Privacy Dynamics software installation, if opting to include ExternalDNS or cert-manager

--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -1,0 +1,76 @@
+data "azurerm_subscription" "current" {
+}
+
+data "azurerm_resource_group" "aks_resource_group" {
+  name                  = var.aks_cluster_information.resource_group
+}
+
+resource "azurerm_dns_zone" "pvcy_zone" {
+  name                  = var.aks_cluster_information.dns_zone_name
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+}
+
+resource "azurerm_storage_account" "backups" {
+  name                      = var.aks_cluster_information.storage_account
+  resource_group_name       = data.azurerm_resource_group.aks_resource_group.name
+  location                  = var.aks_cluster_information.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+}
+
+resource "azurerm_user_assigned_identity" "dns_contributor_identity" {
+  location              = var.aks_cluster_information.location
+  name                  = "dns-contributor"
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+}
+
+resource "azurerm_user_assigned_identity" "blob-storage-contributor" {
+  location              = var.aks_cluster_information.location
+  name                  = "blob-storage-contributor"
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+}
+
+resource "azurerm_role_assignment" "dns_contributor" {
+  scope                 = azurerm_dns_zone.pvcy_zone.id
+  role_definition_name  = "DNS Zone Contributor"
+  principal_id          = azurerm_user_assigned_identity.dns_contributor_identity.principal_id
+}
+
+resource "azurerm_role_assignment" "dns_resource_group_reader" {
+  scope                 = data.azurerm_resource_group.aks_resource_group.id
+  role_definition_name  = "Reader"
+  principal_id          = azurerm_user_assigned_identity.dns_contributor_identity.principal_id
+}
+
+resource "azurerm_role_assignment" "storage_blob_data_contributor" {
+  scope                 = azurerm_storage_account.backups.id
+  role_definition_name  = "Storage Blob Data Contributor"
+  principal_id          = azurerm_user_assigned_identity.blob-storage-contributor.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "externaldns_credential" {
+  name                  = var.external-dns.serviceaccount
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+  audience              = ["api://AzureADTokenExchange"]
+  issuer                = var.aks_cluster_information.oidc_issuer_url
+  parent_id             = azurerm_user_assigned_identity.dns_contributor_identity.id
+  subject               = "system:serviceaccount:${var.external-dns.namespace}:${var.external-dns.serviceaccount}"
+}
+
+resource "azurerm_federated_identity_credential" "certmanager_credential" {
+  name                  = var.cert-manager.serviceaccount
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+  audience              = ["api://AzureADTokenExchange"]
+  issuer                = var.aks_cluster_information.oidc_issuer_url
+  parent_id             = azurerm_user_assigned_identity.dns_contributor_identity.id
+  subject               = "system:serviceaccount:${var.cert-manager.namespace}:${var.cert-manager.serviceaccount}"
+}
+
+resource "azurerm_federated_identity_credential" "postgres_credential" {
+  name                  = var.postgres.serviceaccount
+  resource_group_name   = data.azurerm_resource_group.aks_resource_group.name
+  audience              = ["api://AzureADTokenExchange"]
+  issuer                = var.aks_cluster_information.oidc_issuer_url
+  parent_id             = azurerm_user_assigned_identity.blob-storage-contributor.id
+  subject               = "system:serviceaccount:${var.postgres.namespace}:${var.postgres.serviceaccount}"
+}

--- a/azure/terraform/outputs.tf
+++ b/azure/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "managed_identity_client_id_blob_storage_contributor" {
+  description = "Client ID of the blob-storage-contributor Managed Identity"
+  value = azurerm_user_assigned_identity.blob-storage-contributor.client_id
+}
+
+output "managed_identity_client_id_dns_contributor" {
+  description = "Client ID of dns-contributor Managed Identity"
+  value = azurerm_user_assigned_identity.dns_contributor_identity.client_id  
+}
+
+output "subscription_id" {
+  description = "Your Azure Subscription ID"
+  value = data.azurerm_subscription.current.subscription_id
+}
+
+output "tenant_id" {
+  description = "Your Azure Tenant ID"
+  value = data.azurerm_subscription.current.tenant_id
+}

--- a/azure/terraform/providers.tf
+++ b/azure/terraform/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = ">= 3.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/azure/terraform/variables.tf
+++ b/azure/terraform/variables.tf
@@ -1,0 +1,49 @@
+variable "aks_cluster_information" {
+  type = object({
+    location        = string
+    resource_group  = string
+    dns_zone_name   = string
+    storage_account = string
+    oidc_issuer_url = string
+  })
+  default = {
+    location        = "AZURE_LOCATION"
+    resource_group  = "AKS-PVCY-GROUP"
+    dns_zone_name   = "PVCY.CUSTOMER.COM"
+    storage_account = "PVCYBACKUPS"
+    oidc_issuer_url = "https://LOCATION.oic.prod-aks.azure.com/SUBSCRIPTION_ID/TENANT_ID/"
+  }
+}
+
+variable "external-dns" {
+    type = object({
+    namespace       = string
+    serviceaccount  = string
+  })
+  default = {
+    namespace       = "external-dns"
+    serviceaccount  = "external-dns"
+  }
+}
+
+variable "cert-manager" {
+  type = object({
+    namespace       = string
+    serviceaccount  = string
+  })
+  default = {
+    namespace       = "cert-manager"
+    serviceaccount  = "cert-manager"
+  }
+}
+
+variable "postgres" {
+  type = object({
+    namespace       = string
+    serviceaccount  = string
+  })
+  default = {
+    namespace       = "pvcy"
+    serviceaccount  = "postgres"
+  }
+}


### PR DESCRIPTION
This creates Managed Identites on Azure for ExternalDNS, cert-manager, and a CloudNative-PG cluster named `postgres`. It also associates Federated Credentials with them. These Managed Identities' Client IDs can then be reference in Kubernetes ServiceAccounts. I could have created those here, but--at least for Azure--the ServiceAccounts are created by KOTS/Helm.