### PR TITLE
Terraform for AWS IRSA

### DIFF
--- a/aws/terraform/README.md
+++ b/aws/terraform/README.md
@@ -1,0 +1,38 @@
+# AWS Terraform Modules
+
+These Terraform modules provide partial automation of the Kubernetes cluster setup, as outlined in the Privacy Dynamics [Self-Hosted Install](https://www.privacydynamics.io/docs/enterprise/self-hosted-install) documentation.
+
+## IAMServiceAccounts
+
+This module creates IAM Roles and Policies, as well as Kubernetes ServiceAccounts, to allow certain workloads access to AWS resources, such as Route 53 and S3. See the [module README](modules/iamserviceaccounts/README.md) for details.
+
+### Required Values
+
+The following values must be set when invoking this module from `main.tf`.
+
+#### variables.tf
+
+See the [module README](modules/iamserviceaccounts/README.md) for the full list of possible variables.
+
+- `dns_zone_name` = the subdomain for a new DNS zone, the module will attempt to create this DNS Zone in Route 53
+- `eks_cluster_name` = the name of an existing EKS cluster
+- `oidc_provider_url` = the URL of an existing OpenID Connect (OIDC) Provider ([see the AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) to enable an OIDC Provider for your cluster)
+- `s3_bucket` = the name for a new S3 Bucket to hold application database backups; the module will attempt to create this Bucket, remember that S3 Bucket names must be globally unique
+
+#### providers.tf
+
+See the documentation for the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) and the [Kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs) for full details of possible values in `providers.tf`.
+
+- `region` = the region of the EKS cluster
+- `profile` = the AWS CLI profile for the EKS cluster
+- `config_path` = the file path to your local Kubeconfig file, default is `~/.kube/config`
+- `config_context` = the name of the context for your EKS cluster[^1]
+
+### Required Tools
+
+This module depend on other utilities for access to remote resources. The following are required:
+
+- [AWS CLI](https://aws.amazon.com/cli/), logged in to an account with access to the EKS cluster
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/), with a [properly configured kubeconfig file](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html), allowing access to the EKS cluster
+
+[^1]: Run `kubectl config get-contexts` to see a list of all contexts in your kubeconfig file; if `config_context` is not set in `providers.tf`, it will default to your current Kubernetes context, as long as one is set in your kubeconfig file

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -1,0 +1,7 @@
+module "iamserviceaccounts" {
+  source            = "./modules/iamserviceaccounts"
+  dns_zone_name     = "PVCY.CUSTOMER.COM"
+  eks_cluster_name  = "EKS_NAME"
+  oidc_provider_url = "https://oidc.eks.REGION.amazonaws.com/id/ABC123"
+  s3_bucket         = "BACKUPS_S3_BUCKET"
+}

--- a/aws/terraform/modules/iamserviceaccounts/README.md
+++ b/aws/terraform/modules/iamserviceaccounts/README.md
@@ -1,0 +1,43 @@
+# IAMServiceAccounts Module
+
+This module creates IAM Roles and Policies, as well as Kubernetes `ServiceAccount` resources, to allow certain workloads access to AWS resources, such as Route 53 and S3. Some of these are intended to provide access for EKS Add-ons, while others are intended for Helm deployments that will be installed with Replicated.
+
+## Resources
+
+The Terraform files provided here will create the following resources:
+
+- A Route 53 DNS Zone for Privacy Dynamics software
+- An S3 bucket for backups of the Privacy Dynamics application database
+- Seven IAM Roles for Service Accounts (IRSA), with their attached IAM Policies
+- Seven Kubernetes ServiceAccounts, each linked to one of the IAM Roles
+
+An IRSA role has a Trust Relationship allowing outside API requests to assume the role, as long as the requests come from a specific Kubernetes ServiceAccount through an OpenID Connect (OIDC) Provider. This Role can then manipulate AWS resources allowed in the attached IAM Policy. See [our documentation](https://www.privacydynamics.io/docs/enterprise/aws_iamserviceaccounts) for a complete listing of these Roles.
+
+> NOTE: The `eksctl` utility, which can be used to manually create these ServiceAccounts and Roles (referred to collectively as IAMServiceAccounts), uses CloudFormation to create the necessary resources. If requested to display a list of existing IAMServiceAccounts on a cluster, it queries CloudFormation for the information. As Terraform does not employ CloudFormation, `eksctl get iamserviceaccounts` will not show resources created with Terraform. However, the resources will function as intended and are equivalent in every other way.
+
+## Variables
+
+The following variables must be set in order for this module to run correctly. Several variables have default values that should work in most cases, but can be overriden by defining a value when invoking this module from the parent `main.tf` file. Variables without a default value must have a value supplied from the parent `main.tf` in order for this module to run successfully.
+
+| Variable                    | Description                                                   | Default                      |
+|-----------------------------|---------------------------------------------------------------|------------------------------|
+| `aws_node_sa.name`          | name of the aws-node ServiceAccount                           | aws-node                     |
+| `aws_node_sa.namespace`     | namespace of the aws-node ServiceAccount                      | kube-system                  |
+| `aws_lbc_sa.name`           | name of the aws-load-balancer-controller ServiceAccount       | aws-load-balancer-controller |
+| `aws_lbc_sa.namespace`      | namespace of the aws-load-balancer-controller ServiceAccount  | kube-system                  |
+| `ebs_csi_controller_sa.name`| name of the ebs-csi-controller-sa ServiceAccount              | ebs-csi-controller-sa        |
+| `ebs_csi_controller_sa.namespace` | namespace of the ebs-csi-controller-sa ServiceAccount   | kube-system                  |
+| `efs_csi_controller_sa.name`| name of the efs-csi-controller-sa ServiceAccount              | efs-csi-controller-sa        |
+| `efs_csi_controller_sa.namespace` | namespace of the efs-csi-controller-sa ServiceAccount   | kube-system                  |
+| `cert_manager_sa.name`      | name of the cert-manager ServiceAccount                       | cert-manager                 |
+| `cert_manager_sa.namespace` | namespace of the cert-manager ServiceAccount                  | cert-manager                 |
+| `dns_zone_name`             | the subdomain for the DNS zone to be created                  |                              |
+| `eks_cluster_name`          | the name of the EKS cluster                                   |                              |
+| `external_dns_sa.name`      | name of the external-dns ServiceAccount                       | external-dns                 |
+| `external_dns_sa.namespace` | namespace of the external-dns ServiceAccount                  | external-dns                 |
+| `oidc_provider_url`         | the URL of the OpenID Connect (OIDC) Issuer[^1]               |                              |
+| `postgres_sa.name`          | name of the postgres ServiceAccount                           | postgres                     |
+| `postgres_sa.namespace`     | namespace of the postgres ServiceAccount                      | pvcy                         |
+| `s3_bucket`                 | the name for S3 Bucket to be created                          |                              |
+
+[^1]: See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for details on finding or creating your cluster's OIDC Issuer URL

--- a/aws/terraform/modules/iamserviceaccounts/aws_lbc_policy.json
+++ b/aws/terraform/modules/iamserviceaccounts/aws_lbc_policy.json
@@ -1,0 +1,241 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSecurityGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "elasticloadbalancing:CreateAction": [
+            "CreateTargetGroup",
+            "CreateLoadBalancer"
+          ]
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/aws/terraform/modules/iamserviceaccounts/main.tf
+++ b/aws/terraform/modules/iamserviceaccounts/main.tf
@@ -1,0 +1,319 @@
+data "aws_iam_openid_connect_provider" "this" {
+  url = var.oidc_provider_url
+}
+
+resource "aws_route53_zone" "pvcy_zone" {
+  name = var.dns_zone_name
+}
+
+resource "aws_s3_bucket" "backups" {
+  bucket = var.s3_bucket
+}
+
+resource "aws_iam_policy" "aws_load_balancer_controller_policy" {
+  name = "AWSLoadBalancerControllerPolicy"
+  policy = file("${path.module}/aws_lbc_policy.json")
+}
+
+resource "aws_iam_policy" "certmanager_policy" {
+  name = "pvcy-cert-manager-route53-access"
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "route53:GetChange",
+        "Resource": "arn:aws:route53:::change/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "route53:ChangeResourceRecordSets",
+          "route53:ListResourceRecordSets"
+        ],
+        "Resource": "arn:aws:route53:::hostedzone/${aws_route53_zone.pvcy_zone.zone_id}"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "route53:ListHostedZonesByName",
+        "Resource": "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "externaldns_policy" {
+  name = "pvcy-external-dns-route53-access"
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "route53:ChangeResourceRecordSets"
+        ],
+        "Resource": [
+          "arn:aws:route53:::hostedzone/${aws_route53_zone.pvcy_zone.zone_id}"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "route53:ListHostedZones",
+          "route53:ListResourceRecordSets",
+          "route53:ListTagsForResource"
+        ],
+        "Resource": [
+          "*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "backup_access_policy" {
+  name = "pvcy-backup-s3-access"
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "VisualEditor0",
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListBucket",
+          "s3:PutObjectTagging",
+          "s3:DeleteObject"
+        ],
+        "Resource": [
+          "${aws_s3_bucket.backups.arn}/*",
+          "${aws_s3_bucket.backups.arn}"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "aws_lbc_role" {
+  name = "${var.eks_cluster_name}-aws-load-balancer-controller-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.aws_lbc_sa.namespace}:${var.aws_lbc_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = [aws_iam_policy.aws_load_balancer_controller_policy.arn]
+}
+
+resource "aws_iam_role" "aws_node_role" {
+  name = "${var.eks_cluster_name}-aws-node-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.aws_node_sa.namespace}:${var.aws_node_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+}
+
+resource "aws_iam_role" "cert-manager-role" {
+  name = "${var.eks_cluster_name}-cert-manager-serviceaccount-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.cert_manager_sa.namespace}:${var.cert_manager_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = [aws_iam_policy.certmanager_policy.arn]
+}
+
+resource "aws_iam_role" "ebs_csi_controller_role" {
+  name = "${var.eks_cluster_name}-ebs-csi-controller-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.ebs_csi_controller_sa.namespace}:${var.ebs_csi_controller_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"]
+}
+
+resource "aws_iam_role" "efs_csi_controller_role" {
+  name = "${var.eks_cluster_name}-efs-csi-controller-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.efs_csi_controller_sa.namespace}:${var.efs_csi_controller_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"]
+}
+
+resource "aws_iam_role" "external-dns-role" {
+  name = "${var.eks_cluster_name}-external-dns-serviceaccount-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.external_dns_sa.namespace}:${var.external_dns_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = [aws_iam_policy.externaldns_policy.arn]
+}
+
+resource "aws_iam_role" "postgres-role" {
+  name = "${var.eks_cluster_name}-postgres-serviceaccount-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.this.url}:aud" = "sts.amazonaws.com",
+            "${data.aws_iam_openid_connect_provider.this.url}:sub" = "system:serviceaccount:${var.postgres_sa.namespace}:${var.postgres_sa.name}"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          Federated = "${data.aws_iam_openid_connect_provider.this.arn}"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = [aws_iam_policy.backup_access_policy.arn]
+}
+
+resource "kubernetes_namespace" "cert-manager_ns" {
+  metadata {
+    name = var.cert_manager_sa.namespace
+  }
+}
+
+resource "kubernetes_namespace" "external-dns_ns" {
+  metadata {
+    name = var.external_dns_sa.namespace
+  }
+}
+
+resource "kubernetes_namespace" "postgres_ns" {
+  metadata {
+    name = var.postgres_sa.namespace
+  }
+}
+
+resource "kubernetes_service_account" "externaldns_serviceaccount" {
+  depends_on = [ kubernetes_namespace.external-dns_ns ]
+  metadata {
+    name        = var.external_dns_sa.name
+    namespace   = var.external_dns_sa.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.external-dns-role.arn
+    }
+  }
+}
+
+resource "kubernetes_service_account" "certmanager_serviceaccount" {
+  depends_on = [ kubernetes_namespace.cert-manager_ns ]
+  metadata {
+    name        = var.cert_manager_sa.name
+    namespace   = var.cert_manager_sa.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.cert-manager-role.arn
+    }
+  }
+}
+
+resource "kubernetes_service_account" "postgres_serviceaccount" {
+  depends_on = [ kubernetes_namespace.postgres_ns ]
+  metadata {
+    name        = var.postgres_sa.name
+    namespace   = var.postgres_sa.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.postgres-role.arn
+    }
+  }
+}
+
+resource "kubernetes_service_account" "aws_lbc_serviceaccount" {
+  metadata {
+    name        = var.aws_lbc_sa.name
+    namespace   = var.aws_lbc_sa.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.aws_lbc_role.arn
+    }
+  }
+}

--- a/aws/terraform/modules/iamserviceaccounts/variables.tf
+++ b/aws/terraform/modules/iamserviceaccounts/variables.tf
@@ -1,0 +1,103 @@
+variable "aws_lbc_sa" {
+  description = "Name and namespace of the aws-load-balancer-controller ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "aws-load-balancer-controller"
+    namespace = "kube-system"
+  }
+}
+
+variable "aws_node_sa" {
+  description = "Name and namespace of the aws-node ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "aws-node"
+    namespace = "kube-system"
+  }
+}
+
+variable "cert_manager_sa" {
+  description = "Name and namespace of the cert-manager ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "cert-manager"
+    namespace = "cert-manager"
+  }
+}
+
+variable "dns_zone_name" {
+  description = "Subdomain to be managed by the DNS Zone"
+  type = string
+}
+
+variable "ebs_csi_controller_sa" {
+  description = "Name and namespace of the ebs-csi-controller-sa ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "ebs-csi-controller-sa"
+    namespace = "kube-system"
+  }
+}
+
+variable "efs_csi_controller_sa" {
+  description = "Name and namespace of the efs-csi-controller-sa ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "efs-csi-controller-sa"
+    namespace = "kube-system"
+  }
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  type = string
+}
+
+variable "external_dns_sa" {
+  description = "Name and namespace of the external-dns ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "external-dns"
+    namespace = "external-dns"
+  }
+}
+
+variable "oidc_provider_url" {
+  description = "URL of the OpenID Connect (OIDC) Provider for the EKS cluster"
+  type = string
+}
+
+
+variable "postgres_sa" {
+  description = "Name and namespace of the postgres ServiceAccount"
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = {
+    name      = "postgres"
+    namespace = "pvcy"
+  }
+}
+variable "s3_bucket" {
+  description = "AWS S3 bucket to hold backups of the application database"
+  type = string
+}

--- a/aws/terraform/providers.tf
+++ b/aws/terraform/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "AWS_REGION"
+  profile = "AWS_PROFILE"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+  config_context = "KUBECONFIG_CONTEXT"
+}


### PR DESCRIPTION
This adds support to create IAMServiceAccounts and associated AWS resources (DNS Zone and S3 Bucket) through Terraform.

I employed a modular structure so I can add other features later, such as the EFS filesystem.