### PR TITLE
Associate OIDC Provider in Terraform

### DIFF
--- a/aws/terraform/README.md
+++ b/aws/terraform/README.md
@@ -32,7 +32,6 @@ The following values must be set when invoking this module from `main.tf`. See t
 
 - `dns_zone_name` = the subdomain for a new DNS zone, the module will attempt to create this DNS Zone in Route 53
 - `eks_cluster_name` = the name of an existing EKS cluster
-- `oidc_provider_url` = the URL of an existing OpenID Connect (OIDC) Provider ([see the AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) to enable an OIDC Provider for your cluster)
 - `s3_bucket` = the name for a new S3 Bucket to hold application database backups; the module will attempt to create this Bucket[^2]
 
 [^2]: Remember that S3 Bucket names must be globally unique

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -7,7 +7,6 @@ module "iamserviceaccounts" {
   source            = "./modules/iamserviceaccounts"
   dns_zone_name     = "PVCY.CUSTOMER.COM"
   eks_cluster_name  = var.cluster_name
-  oidc_provider_url = "https://oidc.eks.REGION.amazonaws.com/id/ABC123"
   s3_bucket         = "BACKUPS_S3_BUCKET"
 }
 

--- a/aws/terraform/modules/iamserviceaccounts/README.md
+++ b/aws/terraform/modules/iamserviceaccounts/README.md
@@ -35,9 +35,6 @@ The following variables must be set in order for this module to run correctly. S
 | `eks_cluster_name`          | the name of the EKS cluster                                   |                              |
 | `external_dns_sa.name`      | name of the external-dns ServiceAccount                       | external-dns                 |
 | `external_dns_sa.namespace` | namespace of the external-dns ServiceAccount                  | external-dns                 |
-| `oidc_provider_url`         | the URL of the OpenID Connect (OIDC) Issuer[^1]               |                              |
 | `postgres_sa.name`          | name of the postgres ServiceAccount                           | postgres                     |
 | `postgres_sa.namespace`     | namespace of the postgres ServiceAccount                      | pvcy                         |
 | `s3_bucket`                 | the name for S3 Bucket to be created                          |                              |
-
-[^1]: See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for details on finding or creating your cluster's OIDC Issuer URL

--- a/aws/terraform/modules/iamserviceaccounts/variables.tf
+++ b/aws/terraform/modules/iamserviceaccounts/variables.tf
@@ -80,12 +80,6 @@ variable "external_dns_sa" {
   }
 }
 
-variable "oidc_provider_url" {
-  description = "URL of the OpenID Connect (OIDC) Provider for the EKS cluster"
-  type        = string
-}
-
-
 variable "postgres_sa" {
   description = "Name and namespace of the postgres ServiceAccount"
   type = object({


### PR DESCRIPTION
For #22. This automatically associates an OIDC provider with the given EKS cluster.